### PR TITLE
Update link to Anaconda navigator

### DIFF
--- a/docs/notebooks/first_steps.ipynb
+++ b/docs/notebooks/first_steps.ipynb
@@ -20,7 +20,7 @@
     "[Jupyter Notebook examples](https://github.com/1kastner/conflowgen/tree/main/examples/Jupyter_Notebook).\n",
     "During the environment set up, ConFlowGen is automatically installed.\n",
     "Then, you can start JupyterLab\n",
-    "[from Anaconda Navigator](https://docs.anaconda.com/anaconda/navigator/index.html)\n",
+    "[from Anaconda Navigator](https://docs.anaconda.com/free/navigator/)\n",
     "or\n",
     "[from the CLI](https://jupyterlab.readthedocs.io/en/stable/getting_started/starting.html).\n",
     "Please ensure that you are in the correct conda environment (it should be `conflowgen`) when you work."


### PR DESCRIPTION
previous link https://docs.anaconda.com/anaconda/navigator/index.html resulted in a 404, content moved to https://docs.anaconda.com/free/navigator/