### PR TITLE
Use kaleido 0.1.* to make unittests run again

### DIFF
--- a/.github/workflows/installation-from-remote.yaml
+++ b/.github/workflows/installation-from-remote.yaml
@@ -38,7 +38,7 @@ jobs:
       run: |
         conda activate test-install-conflowgen
         conda install -c conda-forge 'pillow>=9.0'
-        kaleido_get_chrome -y
+        plotly_get_chrome -y
 
     - name: Run tests
       run: |

--- a/.github/workflows/installation-from-remote.yaml
+++ b/.github/workflows/installation-from-remote.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Prepare tests
       run: |
         conda activate test-install-conflowgen
-        conda install -c conda-forge 'pillow>=9.0' 'kaleido<0.2'
+        conda install -c conda-forge 'pillow>=9.0' 'python-kaleido<0.2'
 
     - name: Run tests
       run: |

--- a/.github/workflows/installation-from-remote.yaml
+++ b/.github/workflows/installation-from-remote.yaml
@@ -37,8 +37,7 @@ jobs:
     - name: Prepare tests
       run: |
         conda activate test-install-conflowgen
-        conda install -c conda-forge 'pillow>=9.0'
-        plotly_get_chrome -y
+        conda install -c conda-forge 'pillow>=9.0' 'kaleido<0.2'
 
     - name: Run tests
       run: |

--- a/.github/workflows/installation-from-remote.yaml
+++ b/.github/workflows/installation-from-remote.yaml
@@ -37,7 +37,8 @@ jobs:
     - name: Prepare tests
       run: |
         conda activate test-install-conflowgen
-        conda install -c conda-forge pillow>=9.0
+        conda install -c conda-forge 'pillow>=9.0'
+        kaleido_get_chrome -y
 
     - name: Run tests
       run: |


### PR DESCRIPTION
See https://stackoverflow.com/questions/69016568/unable-to-export-plotly-images-to-png-with-kaleido?noredirect=1&lq=1

Hopefully the bug gets resolved and we can use an up-to-date version of kaleido again soon.